### PR TITLE
Adding tacit - user-friendly CSS framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,9 @@
 - **[SVG Sprite Loader](https://github.com/JetBrains/svg-sprite-loader)** by [Stas Kurilov](https://github.com/kisenka)<br>
   Webpack loader for creating SVG sprites.
   
+- **[Tacit](https://github.com/yegor256/tacit)** by [Yegor Bugayenko](https://github.com/yegor256)<br>
+  CSS Framework for Dummies, without Classes.
+  
 - **[Tarantool](https://github.com/tarantool/tarantool)** by [Mail.Ru Group](https://github.com/mailru)<br>
   An in-memory database and application server.
   


### PR DESCRIPTION
### What is tacit:
Tacit is a primitive CSS framework for dummies, like myself, who don't know anything about graphic design but want their web services to look eatable. No classes, no layouts. Just design plain and simple web pages compliant with HTML5 and they will look OK.

### About author:
Yegor - is russian open-source enthusiast, proactive github contributor.