### PR TITLE
Add tinyhttp to the list of 1K stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,8 @@
 
 - **[Yolo Mark](https://github.com/AlexeyAB/Yolo_mark)** by [Alexey Bochkovskiy](https://github.com/AlexeyAB)<br>
   GUI for marking bounded boxes of objects in images for training neural network Yolo v3 and v2.
+  
+- **[tinyhttp](https://github.com/talentlessguy/tinyhttp)** by [Pavel Losev](https://github.com/talentlessguy)
 
 - The place for your next great pet project!
 


### PR DESCRIPTION
Hello!

Recently one of my project hit 1K stars on GitHub, here's the [link to it](https://github.com/talentlessguy/tinyhttp).

At the moment of making this pull request the repo has 1018 stars. I'd like to submit my project to this list in ">1K stars" category